### PR TITLE
Add Dutch (nl) website translation

### DIFF
--- a/nl.php
+++ b/nl.php
@@ -1,0 +1,257 @@
+<?php
+
+$LANG = array(
+
+# Global
+'TRANSLATED_BY' 		    => 'vertaling door: <a href="http://wimiso.nl">Willem Sonke</a>',
+'LANGUAGE_NAME' 			=> 'Nederlands',
+'LANGUAGE_ISO_CODE_2_LETTER'=> 'nl',
+# http://www.w3schools.com/tags/ref_language_codes.asp --> full list
+
+################################################################################
+# Header HTML infos for search engine and title in tab:
+'PEPPERCARROT_VEGETABLE'    =>  'Peper en Wortel', // litteral translation of spices + vegetable
+'Website_DESCRIPTION'        =>  'De officiële pagina van Pepper&amp;Carrot, een vrije, open-bron webcomic over Pepper, een jonge heks, en haar kat Carrot. Ze wonen in een fantasie-universum met toverdranken, magie en vreemde dieren.',
+'SUBTITLE'                  =>  'de open webcomic door David Revoy',
+
+################################################################################
+# Top menu website:
+'HOMEPAGE'      =>  'Startpagina',
+'WEBCOMICS'     =>  'Strips',
+'BLOG'          =>  'Blog',
+'PHILOSOPHY'    =>  'Filosofie',
+'CONTRIBUTE'    =>  'Bijdragen',
+'SOURCES'       =>  'Bronnen',
+'AUTHOR'        =>  'Auteur',
+'FOLLOW'        =>  'Volg Pepper&amp;Carrot op:',
+
+################################################################################
+# Top and bottom translation panel
+'ADD_TRANSLATION'       => 'vertaling toevoegen',
+'CORRECTIONS' 			=> 'correctie voorstellen',
+
+################################################################################
+# Page : Homepage
+'HOMEPAGE_BIG_TEXT'		    =>  '
+    een vrije en open-bron-webcomic<br/>
+    direct ondersteund door zijn patrons<br/>
+    om de stripboek-industrie te veranderen!<br/>
+',
+'HOMEPAGE_MOREINFO_BUTTON'  =>  'Meer informatie',
+'HOMEPAGE_LAST_EPISODE'     =>  'Nieuwste aflevering:',
+'HOMEPAGE_NEWS_UPDATE'      =>  'Nieuws en updates:',
+'HOMEPAGE_PATREON_BUTTON'   =>  'word een patron van<br/>Pepper&amp;Carrot op',
+'HOMEPAGE_MOREPOSTS_BUTTON' =>  'Meer berichten',
+
+################################################################################
+# Page : Webcomics
+'WEBCOMIC_EPISODE'		    =>  'Webcomic-afleveringen',
+'WEBCOMIC_MAKINGOF'		    =>  'Achter de schermen',
+'WEBCOMIC_MAKINGOF_DESCRIPTION' =>  '
+    <p>De achter-de-schermen-pagina\'s en de <a href="http://www.davidrevoy.com/static4/tutorials">teken-tutorials</a> zijn een speciale bonus, gesponsord door mijn <a href="https://www.patreon.com/davidrevoy">Patreons &#39;helden&#39;</a></p>
+',
+'WEBCOMIC_ARTWORK'		    =>  'Galerij',
+'WEBCOMIC_SKETCHES'		    =>  'Schetsen',
+
+################################################################################
+# Page : Blog
+# when content are not English ( no need to warn user the content is english only here ) :
+#'LIMITATIONS' 	=> '<i class="fa fa-info-circle"></i> Content available in english only ',
+'LIMITATIONS' 		=> '<i class="fa fa-info-circle"></i> Pagina alleen beschikbaar in het Engels',
+
+################################################################################
+# Page : Philosophy
+'PHILOSOPHY_CONTENT'    =>  '
+ <h2>Ondersteund door patrons</h2>
+    
+    <p>Het Pepper&amp;Carrot-project wordt alleen ondersteund door zijn patrons, van over de hele wereld.<br/>
+    Alle patrons doneren een klein beetje geld voor iedere nieuwe gepubliceerde aflevering en krijgen credit aan het eind van de aflevering.<br/>
+    Door dit systeem kan Pepper&amp;Carrot onafhankelijk zijn en nooit advertenties of andere marketing-vervuiling gebruiken.</p>
+    
+    <div class="philobutton">
+        <a href="https://www.patreon.com/davidrevoy" title="Voor slechts $1,- per aflevering kun je patron van Pepper&amp;Carrot worden">
+            Voor slechts $1,- per aflevering kun je patron worden op Patreon
+        </a>
+    </div>
+    
+        <img alt="afbeelding die patrons voorstelt" src="data/images/static/2015-02-09_philosophy_01-support.jpg">
+
+
+    <h2>100% gratis, altijd, zonder paywall</h2>
+    
+    <p>Alles wat ik produceer van Pepper&amp;Carrot staat op deze website, gratis en voor iedereen beschikbaar.<br/>
+    Ik respecteer iedereen even veel: of je geld geeft of niet. Alle speciale bonussen die ik maak voor mijn patrons zet ik ook hier.<br/>
+    Pepper&amp;Carrot zal je nooit vragen om iets te betalen of een abonnement te nemen om toegang te krijgen tot nieuwe dingen.</p>
+    
+        <img alt="afbeelding die een paywall voorstelt" src="data/images/static/2015-02-09_philosophy_03-paywall.jpg">
+
+    <h2>Open-bron en vrij beschikbaar</h2>
+    
+    <p>Ik wil mensen het recht geven om mijn werk te delen en gebruiken, en zelfs om er geld aan te verdienen.<br/>
+    Alle pagina\'s, tekeningen en andere inhoud zijn gemaakt met vrije open-bron-software op GNU/Linux, en alle bronbestanden staan op deze website (het &#39;Bronnen&#39;-menu).<br/>
+    Ik moedig commercieel gebruik, vertalingen, fanart, prints, films, videospellen, delen en reposts aan.<br/>
+    Je hoeft alleen maar mij - David Revoy - als auteur te vermelden.</p>
+    
+    <div class="philobutton">
+        <a href="https://creativecommons.org/licenses/by/3.0/" title="Lees voor meer informatie de Creative Commons Naamsvermelding-licentie">
+            Licentie: Creative Commons Naamsvermelding
+        </a>
+    </div>
+
+        <img alt="afbeelding die open-bron-media voorstelt" src="data/images/static/2015-02-09_philosophy_04-open-source.jpg">
+
+    <h2>Kwaliteits-entertainment voor iedereen, overal</h2>
+    
+    <p>Pepper&amp;Carrot is een comedy/humor-webcomic voor iedereen, van iedere leeftijd.<br/>
+    Geen inhoud voor volwassenen, geen geweld. Pepper&amp;Carrot is, als vrij beschikbare strip, een trots voorbeeld van hoe mooi vrije cultuur kan zijn.<br/>
+    Ik focus op kwaliteit, want vrij en open-bron betekent niet dat iets slecht of amateuristisch is. Andersom, juist.</p>
+
+        <img alt="" src="data/images/static/2015-02-09_philosophy_05-everyone.jpg">
+
+    <h2>Laten we de stripboeken-industrie veranderen!</h2>
+    
+    <p>Met minder tussenstappen tussen het publiek en de tekenaar betaal jij minder en verdien ik meer. Je ondersteunt me direct.<br/>
+    Geen enkele uitgever/distributeur/marketingafdeling/trend kan me dwingen om Pepper&amp;Carrot aan te passen om te passen bij hun visie op wat &#39;de markt&#39; wil.<br/>
+    Een enkel succes kan als een &#39;sneeuwbal&#39; de hele industrie veranderen. Laten we het proberen!</p>
+    
+        <img alt="afbeelding: de stripboeken-industrie versus ondersteuning door patrons" src="data/images/static/2015-02-09_philosophy_06-industry-change.jpg">
+
+    <h2>Waarom heeft Pepper&amp;Carrot geld nodig?</h2>
+    
+    <p>Om Pepper&amp;Carrot fulltime te tekenen, en een dak boven mijn hoofd te hebben, heb ik $900,- per aflevering nodig, uitgaande van twee afleveringen per maand.<br/>
+    Die $900,- is geen magisch getal: ik heb dat berekend op basis van het Franse minimumloon, rekening houdend met de belasting die een onafhankelijke artiest moet betalen.<br/>
+    Met minder dan $900,- moet ik freelance-werk blijven doen (trage Pepper&amp;Carrot-productie, minder dan één aflevering per maand).<br/>
+    Met meer dan $900,- kan ik Pepper&amp;Carrot fulltime gaan tekenen (snelle Pepper&amp;Carrot-productie, twee afleveringen per maand).</p>
+    
+    <div class="philobutton">
+        <a href="https://www.patreon.com/davidrevoy" title="Voor maar $1,- per aflevering kun je patron van Pepper&amp;Carrot worden">
+            help me om de productie van Pepper&amp;Carrot sneller te maken
+        </a> 
+    </div>
+        
+    <img alt="" src="data/images/static/2015-02-09_philosophy_02-money-meter.jpg"> 
+    
+    <p>Bedankt voor het lezen! <br/>
+    -David Revoy</p>
+ 
+ ',
+ 
+################################################################################
+# Page : Contribute 
+'CONTRIBUTE_TITLE'		=> 'Bijdragen',
+'CONTRIBUTE_TOP'		=> '
+    <p>Dankzij de <a href="?static6/sources" title="Sources page">open bronbestanden</a> en de <a href="http://creativecommons.org/licenses/by/3.0/">
+    Creative Commons-licentie</a> kun je op vele manieren bijdragen aan Pepper&amp;Carrot:</p>
+            
+    <h2>Als patron, donaties</h2>
+    
+    <p>Op de pagina <a href="?static2/philosophy" title="open de Filosofie-pagina">Filosofie</a> leg ik alles uit over donaties.<br/>
+    Het is makkelijk om patron van Pepper&amp;Carrot te worden voor slechts $1,- per nieuwe aflevering <a href="https://www.patreon.com/davidrevoy">op Patreon</a>.<br/>
+    Patreon accepteert creditcards uit de hele wereld, en je kunt betalen met een PayPal-account op Patreon.<br/>
+            </p>
+',
+'CONTRIBUTE_FANART'	    => '
+    <h2>Fanart</h2>
+    <p>Pepper&amp;Carrot staat open voor fanart: tekeningen, scenario\'s, beelden, 3D-modellen, fanfictions. Als je ze naar mij opstuurt, dan (<a href="mailto:info@davidrevoy.com">info@davidrevoy.com</a>, of via de sociale netwerken) zet ik ze in de fanart-galerij:</p>
+',
+'CONTRIBUTE_DERIVATIONS' => '
+    <h2>Afgeleide werken:</h2>
+    <p>Pepper&amp;Carrot kan worden gebruikt bij vele projecten or producten, waarom gebruik je het niet bij je eigen project, of doe je mee met een bestaand project?</p>
+',
+
+'CONTRIBUTE_BOTTOM'	    => '
+    <h2>Vertalingen en correcties:</h2>
+    
+    <p>De Pepper&amp;Carrot-website is meertalig en accepteert iedere taal (ook dode talen, of fictieve). De broncode van deze pagina zijn beschikbaar zodat je ze kunt vertalen. Bekijk de <a href="index.php?fr/article267/translation-tutorial">tutorial</a> voor meer informatie over het toevoegen van een vertaling.</p>
+            
+    <h2>Pers, sociale media</h2> 
+    
+    <p>Word de uitgever van Pepper&amp;Carrot! Schrijf artikelen, zet een post op je website, deel het op je favoriete sociale medium. Je kunt de <a href="?static6/sources" title="Bronnen-pagina">pers-kit</a> downloaden op de bronnen-pagina.</p>
+    
+    <h2>Andere ideeën...</h2>
+    
+    <p>Iedereen kan bijdragen op verschillende manieren:<br/>
+        <b>Ontwikkelaars:</b> Maak een applicatie om Pepper&amp;Carrot te lezen op mobiele apparaten.<br />
+        <b>Muzikanten:</b> Schrijf muziek-thema\'s voor Pepper&amp;Carrot.<br />
+        <b>Schrijvers:</b> Stel een nieuw scenario voor voor Pepper&amp;Carrot.<br />
+        <b>Journalisten:</b> Bericht over Pepper&amp;Carrot in traditionele media (de pers, televisie, enzovoorts)<br />
+        <b>Drukkerijen:</b> Druk posters of andere dingen met Pepper&amp;Carrot erop.<br />
+    </p> 
+            
+    <h2>IRC-kanaal:</h2>
+    
+    <p>Chat hier om over Pepper&amp;Carrot te discussiëren. Ik ben overdag (Europese tijd) online (met schermnaam deevad).<br/>
+',
+
+################################################################################
+# Page : Sources
+'SOURCES_TITLE'		    => 'Bronnen',
+'SOURCES_TOP'	        => '
+    <p><b>Welkom bij het downloadcentrum voor bronbestanden!</b><br/>
+    Hier vind je de bronbestanden van Pepper&amp;Carrot en meer.<br/>
+    Alle tekeningen hier zijn compatibel met de recentste versie van <a href="https://krita.org/">Krita</a>.</p>
+',
+'SOURCES_BOTTOM'	    => '
+    <p>Door deze bestanden te downloaden en ermee te werken, ga je ermee akkoord de termen van de<br/>
+    <a href="http://creativecommons.org/licenses/by/3.0/">Creative Commons Attribution license</a> te respecteren.
+    Bekijk de README-bestanden in ieder project voor meer informatie.</p>
+  
+    <p><b><i class="fa fa-github" style="font-size:1.5em;" ></i> Code-repository\'s voor vertalingen, scripts, de website, tekeningen, enzovoorts:</b><br/></p>
+',
+'SOURCE_COVER'   =>  'Cover-afbeeldingen',
+'SOURCE_KRITA'   =>  'Krita-bronbestanden',
+'SOURCE_TRANSLATOR'=>  'Bestanden voor vertalers',
+'SOURCE_WEB'      =>  'Web <span class="sourceinfos">90ppi, klein JPEG-formaat</span>',
+'SOURCE_PRINT'        =>  'Print <span class="sourceinfos">300ppi, verliesloze compressie</span>',
+'SOURCE_MONTAGE'   =>  'Montage <span class="sourceinfos">Alle plaatjes op één pagina</span>',
+
+################################################################################
+# Page : Author
+'AUTHOR_TITLE'		=> 'Over David Revoy',
+'AUTHOR_BIO'	    => '
+    <p>Hoi, mijn naam is David Revoy en ik ben een Franse kunstenaar geboren in 1981. Ik heb mezelf tekenen geleerd en ik heb een passie voor tekenen, schilderen, katten, computers, de GNU/Linux-open-bron-cultuur, het internet, ouderwetse RPG-spelletjes, oude manga en anime, traditionele kunst, Japanse cultuur, fantasy...<br />
+    <br />
+    Na meer dan 10 jaar freelancen in digitaal tekenen, onderwijzen, concept-art, illustratie en regie, heb ik besloten mijn eigen project te beginen. Ik heb eindelijk een manier gevonden om mijn passies met elkaar te combineren; het resultaat is Pepper&amp;Carrot.</p>
+    
+    <p>Mijn portfolio:</p>
+',
+'AUTHOR_TODO_DREAM'	=> '
+    <h3>Mijn TODO-lijst met dromen:</h3>
+
+    <p>
+    ☐ Een praatje geven op een Japanse stripconferentie over Pepper&amp;Carrot<br/>
+    ☐ Een Pepper&amp;Carrot videospel spelen met een gamepad<br/>
+    ☐ Een galerij van honderd fanarts bereiken<br/>
+    ☐ Een Wikipedia-pagina krijgen<br/>
+    ☐ Een foto ontvangen van een cosplay van Pepper<br/>
+    ☐ Een foto ontvangen van een rode kat met de naam Carrot<br/>
+    ☐ Ondersteund worden door 500 patreons<br/>
+    ☐ Honderd afleveringen bereiken<br/>
+    </p>
+',
+
+'AUTHOR_CARREER_TITLE'				 => 'mijn carrière in 7 bubbels:',
+'AUTHOR_CARREER_BUBBLE_DESCRIPTIONS' => '<p></p>',
+
+################################################################################
+# Website General : Footer
+'FOOTER_CONTENT'    => '
+    <p>De strip, tekeningen en teksten zijn vrijgegeven onder de CC-by-licentie, tenzij anders vermeld op de pagina.<br/>
+    Gebruik de naamsvermelding "David Revoy, www.davidrevoy.com". Je kunt me bereiken op info@davidrevoy.com voor meer informatie.</p>
+    
+    <p>Website mogelijk gemaakt door <a href="http://www.pluxml.org" title="PlXml">PluXml</a></p> 
+',
+
+################################################################################
+# various utils :
+'UTIL_NEXT_EPISODE'      =>  'volgende aflevering',
+'UTIL_PREVIOUS_EPISODE'  =>  'vorige aflevering',
+'UTIL_BACK_TO_GALLERY'      =>  'terug naar galerij',
+'UTIL_MORE'      =>  'meer',
+'UTIL_PAGE'      =>  'pagina',
+'UTIL_BY'        =>  'door',
+'UTIL_LICENSE'   =>  'licentie',
+
+);
+
+?>  


### PR DESCRIPTION
Here is a Dutch version of the Pepper & Carrot website :smile: 

Dutch needs some special characters (ë, é). At the moment I just added them to the file as UTF-8 characters. If you want to have them using the HTML escape codes (`&euml;`, `&eacute;`), let me know and I'll change it.
